### PR TITLE
Feat/module comments

### DIFF
--- a/src/main/java/com/ipi/mesi_backend_rpg/controller/ModuleCommentController.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/controller/ModuleCommentController.java
@@ -1,0 +1,65 @@
+package com.ipi.mesi_backend_rpg.controller;
+
+import com.ipi.mesi_backend_rpg.dto.ModuleCommentDTO;
+import com.ipi.mesi_backend_rpg.model.Module;
+import com.ipi.mesi_backend_rpg.model.ModuleVersion;
+import com.ipi.mesi_backend_rpg.service.ModuleCommentService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/comments")
+public class ModuleCommentController {
+
+    private final ModuleCommentService moduleCommentService;
+    public ModuleCommentController(ModuleCommentService moduleCommentService) {
+        this.moduleCommentService = moduleCommentService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ModuleCommentDTO> getModuleCommentById(@PathVariable("id") Long id) {
+        ModuleCommentDTO moduleComment = moduleCommentService.findById(id);
+        return new ResponseEntity<>(moduleComment, HttpStatus.OK);
+    }
+
+
+    @GetMapping("/module/{moduleId}")
+    public ResponseEntity<List<ModuleCommentDTO>> getModuleCommentsByModule(@PathVariable("moduleId") Module module) {
+        List<ModuleCommentDTO> moduleVersions = moduleCommentService.findAllByModule(module);
+        return new ResponseEntity<>(moduleVersions, HttpStatus.OK);
+    }
+
+    @GetMapping("/version/{moduleVersionId}")
+    public ResponseEntity<List<ModuleCommentDTO>> getModuleCommentsByModuleVersion(@PathVariable("moduleVersionId") ModuleVersion moduleVersion) {
+        List<ModuleCommentDTO> moduleVersions = moduleCommentService.findAllByModuleVersion(moduleVersion);
+        return new ResponseEntity<>(moduleVersions, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<ModuleCommentDTO> createModuleComment(
+            @RequestBody ModuleCommentDTO moduleCommentDTO) {
+        ModuleCommentDTO moduleComment = moduleCommentService.createComment(moduleCommentDTO);
+        return new ResponseEntity<>(moduleComment, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ModuleCommentDTO> updateModuleComment(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody ModuleCommentDTO moduleCommentDTO
+    ) {
+        ModuleCommentDTO moduleComment = moduleCommentService.updateComment(moduleCommentDTO, id);
+        return new ResponseEntity<>(moduleComment, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteModuleVersion(@PathVariable("id") Long id) {
+        moduleCommentService.deleteComment(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+}

--- a/src/main/java/com/ipi/mesi_backend_rpg/controller/ModuleCommentController.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/controller/ModuleCommentController.java
@@ -29,14 +29,24 @@ public class ModuleCommentController {
 
 
     @GetMapping("/module/{moduleId}")
-    public ResponseEntity<List<ModuleCommentDTO>> getModuleCommentsByModule(@PathVariable("moduleId") Module module) {
-        List<ModuleCommentDTO> moduleVersions = moduleCommentService.findAllByModule(module);
+    public ResponseEntity<List<ModuleCommentDTO>> getModuleCommentsByModule(
+            @PathVariable("moduleId") Module module,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int limit
+    )
+    {
+        List<ModuleCommentDTO> moduleVersions = moduleCommentService.findAllByModule(module, page, limit);
         return new ResponseEntity<>(moduleVersions, HttpStatus.OK);
     }
 
     @GetMapping("/version/{moduleVersionId}")
-    public ResponseEntity<List<ModuleCommentDTO>> getModuleCommentsByModuleVersion(@PathVariable("moduleVersionId") ModuleVersion moduleVersion) {
-        List<ModuleCommentDTO> moduleVersions = moduleCommentService.findAllByModuleVersion(moduleVersion);
+    public ResponseEntity<List<ModuleCommentDTO>> getModuleCommentsByModuleVersion(
+        @PathVariable("moduleVersionId") ModuleVersion moduleVersion,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "20") int limit
+        )
+    {
+        List<ModuleCommentDTO> moduleVersions = moduleCommentService.findAllByModuleVersion(moduleVersion, page, limit);
         return new ResponseEntity<>(moduleVersions, HttpStatus.OK);
     }
 

--- a/src/main/java/com/ipi/mesi_backend_rpg/controller/ModuleCommentController.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/controller/ModuleCommentController.java
@@ -8,7 +8,6 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 

--- a/src/main/java/com/ipi/mesi_backend_rpg/controller/ModuleController.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/controller/ModuleController.java
@@ -35,6 +35,14 @@ public class ModuleController {
         return new ResponseEntity<>(module, HttpStatus.OK);
     }
 
+    @GetMapping("/most-commented")
+    public ResponseEntity<List<ModuleResponseDTO>> getMostCommentedModules(
+            @RequestParam(defaultValue = "10") int limit,
+            @RequestParam(defaultValue = "0") int page
+            ) {
+        return new ResponseEntity<>(moduleService.getMostCommentedModules(limit, page), HttpStatus.OK);
+    }
+
     @PostMapping
     public ResponseEntity<ModuleResponseDTO> createModule(@Valid @RequestBody ModuleRequestDTO moduleRequestDTO) {
         ModuleResponseDTO module = moduleService.createModule(moduleRequestDTO);

--- a/src/main/java/com/ipi/mesi_backend_rpg/dto/ModuleCommentDTO.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/dto/ModuleCommentDTO.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record ModuleCommentDTO(
         Long id,

--- a/src/main/java/com/ipi/mesi_backend_rpg/dto/ModuleCommentDTO.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/dto/ModuleCommentDTO.java
@@ -1,0 +1,21 @@
+package com.ipi.mesi_backend_rpg.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ModuleCommentDTO(
+        Long id,
+        Long moduleId,
+        Long moduleVersionId,
+        UserDTO user,
+        @NotNull()
+        String comment,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime createdAt,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/ipi/mesi_backend_rpg/mapper/ModuleCommentMapper.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/mapper/ModuleCommentMapper.java
@@ -1,0 +1,52 @@
+package com.ipi.mesi_backend_rpg.mapper;
+
+import com.ipi.mesi_backend_rpg.dto.BlockDTO;
+import com.ipi.mesi_backend_rpg.dto.ModuleCommentDTO;
+import com.ipi.mesi_backend_rpg.dto.ModuleVersionDTO;
+import com.ipi.mesi_backend_rpg.model.Block;
+import com.ipi.mesi_backend_rpg.model.GameSystem;
+import com.ipi.mesi_backend_rpg.model.ModuleComment;
+import com.ipi.mesi_backend_rpg.model.ModuleVersion;
+import com.ipi.mesi_backend_rpg.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ModuleCommentMapper {
+
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+    private final ModuleRepository moduleRepository;
+    private final ModuleVersionRepository moduleVersionRepository;
+
+    public ModuleCommentDTO toDTO(ModuleComment moduleComment) {
+        return new ModuleCommentDTO(
+                moduleComment.getId(),
+                moduleComment.getModule().getId(),
+                moduleComment.getModuleVersion().getId(),
+                userMapper.toDTO(moduleComment.getUser()),
+                moduleComment.getComment(),
+                moduleComment.getCreatedAt(),
+                moduleComment.getUpdatedAt()
+        );
+    }
+
+    public ModuleComment toEntity(ModuleCommentDTO moduleCommentDTO) {
+        ModuleComment moduleComment = new ModuleComment();
+        moduleComment.setId(moduleCommentDTO.id());
+        moduleComment.setModule(moduleRepository.findById(moduleCommentDTO.moduleId())
+                .orElseThrow(() -> new IllegalArgumentException("Module not found")));
+        moduleComment.setModuleVersion(moduleVersionRepository.findById(moduleCommentDTO.moduleVersionId())
+                .orElseThrow(() -> new IllegalArgumentException("ModuleVersion not found")));
+        moduleComment.setUser(userRepository.findById(moduleCommentDTO.user().id())
+                .orElseThrow(() -> new IllegalArgumentException("Utilisateur non trouvé")));
+        moduleComment.setComment(moduleCommentDTO.comment());
+        return moduleComment;
+    }
+}

--- a/src/main/java/com/ipi/mesi_backend_rpg/mapper/ModuleCommentMapper.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/mapper/ModuleCommentMapper.java
@@ -1,12 +1,7 @@
 package com.ipi.mesi_backend_rpg.mapper;
 
-import com.ipi.mesi_backend_rpg.dto.BlockDTO;
 import com.ipi.mesi_backend_rpg.dto.ModuleCommentDTO;
-import com.ipi.mesi_backend_rpg.dto.ModuleVersionDTO;
-import com.ipi.mesi_backend_rpg.model.Block;
-import com.ipi.mesi_backend_rpg.model.GameSystem;
 import com.ipi.mesi_backend_rpg.model.ModuleComment;
-import com.ipi.mesi_backend_rpg.model.ModuleVersion;
 import com.ipi.mesi_backend_rpg.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/ipi/mesi_backend_rpg/model/Module.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/model/Module.java
@@ -61,6 +61,9 @@ public class Module {
     @OneToMany(mappedBy = "module", fetch = FetchType.LAZY)
     private List<IntegratedModuleBlock> moduleBlocks;
 
+    @OneToMany(mappedBy = "module", fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<ModuleComment> comments;
+
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private Picture picture;
 

--- a/src/main/java/com/ipi/mesi_backend_rpg/model/ModuleComment.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/model/ModuleComment.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/com/ipi/mesi_backend_rpg/model/ModuleComment.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/model/ModuleComment.java
@@ -1,0 +1,45 @@
+package com.ipi.mesi_backend_rpg.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+public class ModuleComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Module module;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ModuleVersion moduleVersion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    private String comment;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public ModuleComment(Module module, ModuleVersion moduleVersion, User user, String comment) {
+        this();
+        this.module = module;
+        this.moduleVersion = moduleVersion;
+        this.user = user;
+        this.comment = comment;
+    }
+
+    public ModuleComment() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/ipi/mesi_backend_rpg/model/ModuleVersion.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/model/ModuleVersion.java
@@ -35,6 +35,9 @@ public class ModuleVersion {
     @ManyToOne(fetch = FetchType.LAZY)
     private GameSystem gameSystem;
 
+    @OneToMany(mappedBy = "moduleVersion", orphanRemoval = true)
+    private List<ModuleComment> comments;
+
     public ModuleVersion(Module module, int version, User creator, boolean published, GameSystem gameSystem, String language) {
         this();
         this.module = module;

--- a/src/main/java/com/ipi/mesi_backend_rpg/repository/ModuleCommentRepository.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/repository/ModuleCommentRepository.java
@@ -1,6 +1,5 @@
 package com.ipi.mesi_backend_rpg.repository;
 
-// import com.ipi.mesi_backend_rpg.dto.ModuleVersionDTO;
 import com.ipi.mesi_backend_rpg.model.Module;
 import com.ipi.mesi_backend_rpg.model.ModuleComment;
 import com.ipi.mesi_backend_rpg.model.ModuleVersion;

--- a/src/main/java/com/ipi/mesi_backend_rpg/repository/ModuleCommentRepository.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/repository/ModuleCommentRepository.java
@@ -4,14 +4,14 @@ package com.ipi.mesi_backend_rpg.repository;
 import com.ipi.mesi_backend_rpg.model.Module;
 import com.ipi.mesi_backend_rpg.model.ModuleComment;
 import com.ipi.mesi_backend_rpg.model.ModuleVersion;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Arrays;
 import java.util.List;
 
 @Repository
 public interface ModuleCommentRepository extends JpaRepository<ModuleComment, Long> {
-    List<ModuleComment> findAllByModule(Module module);
-    List<ModuleComment> findAllByModuleVersion(ModuleVersion moduleVersion);
+    List<ModuleComment> findAllByModule(Module module, Pageable pageable);
+    List<ModuleComment> findAllByModuleVersion(ModuleVersion moduleVersion, Pageable pageable);
 }

--- a/src/main/java/com/ipi/mesi_backend_rpg/repository/ModuleCommentRepository.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/repository/ModuleCommentRepository.java
@@ -1,0 +1,17 @@
+package com.ipi.mesi_backend_rpg.repository;
+
+// import com.ipi.mesi_backend_rpg.dto.ModuleVersionDTO;
+import com.ipi.mesi_backend_rpg.model.Module;
+import com.ipi.mesi_backend_rpg.model.ModuleComment;
+import com.ipi.mesi_backend_rpg.model.ModuleVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Repository
+public interface ModuleCommentRepository extends JpaRepository<ModuleComment, Long> {
+    List<ModuleComment> findAllByModule(Module module);
+    List<ModuleComment> findAllByModuleVersion(ModuleVersion moduleVersion);
+}

--- a/src/main/java/com/ipi/mesi_backend_rpg/repository/ModuleRepository.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/repository/ModuleRepository.java
@@ -1,6 +1,5 @@
 package com.ipi.mesi_backend_rpg.repository;
 
-import com.ipi.mesi_backend_rpg.dto.ModuleResponseDTO;
 import com.ipi.mesi_backend_rpg.model.Module;
 
 import java.util.List;

--- a/src/main/java/com/ipi/mesi_backend_rpg/repository/ModuleRepository.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/repository/ModuleRepository.java
@@ -1,5 +1,6 @@
 package com.ipi.mesi_backend_rpg.repository;
 
+import com.ipi.mesi_backend_rpg.dto.ModuleResponseDTO;
 import com.ipi.mesi_backend_rpg.model.Module;
 
 import java.util.List;
@@ -24,4 +25,7 @@ public interface ModuleRepository extends JpaRepository<Module, Long> {
      */
     @Query("SELECT m FROM Module m WHERE LOWER(m.title) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(m.description) LIKE LOWER(CONCAT('%', :query, '%'))")
     List<Module> findByTitleOrDescriptionContainingIgnoreCase(@Param("query") String query, Pageable pageable);
+
+    @Query("SELECT m FROM Module m JOIN ModuleComment c ON c.module = m GROUP BY m ORDER BY COUNT(c) DESC")
+    List<Module> findMostCommentedModules(Pageable pageable);
 }

--- a/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleCommentService.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleCommentService.java
@@ -1,0 +1,78 @@
+package com.ipi.mesi_backend_rpg.service;
+
+import com.ipi.mesi_backend_rpg.dto.ModuleCommentDTO;
+import com.ipi.mesi_backend_rpg.dto.ModuleVersionDTO;
+import com.ipi.mesi_backend_rpg.mapper.BlockMapper;
+import com.ipi.mesi_backend_rpg.mapper.ModuleCommentMapper;
+import com.ipi.mesi_backend_rpg.mapper.ModuleVersionMapper;
+import com.ipi.mesi_backend_rpg.model.Module;
+import com.ipi.mesi_backend_rpg.model.ModuleComment;
+import com.ipi.mesi_backend_rpg.model.ModuleVersion;
+import com.ipi.mesi_backend_rpg.repository.ModuleCommentRepository;
+import com.ipi.mesi_backend_rpg.repository.ModuleVersionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ModuleCommentService {
+
+    private final ModuleCommentRepository moduleCommentRepository;
+    private final ModuleCommentMapper moduleCommentMapper;
+
+    public ModuleCommentDTO findById(Long id) {
+        ModuleComment moduleComment = moduleCommentRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "module comment not found"));
+        return moduleCommentMapper.toDTO(moduleComment);
+    }
+
+    public ModuleCommentDTO createComment(ModuleCommentDTO moduleCommentDTO) {
+        ModuleComment moduleComment = moduleCommentMapper.toEntity(moduleCommentDTO);
+        ModuleComment saved = moduleCommentRepository.save(moduleComment);
+        return moduleCommentMapper.toDTO(saved);
+    }
+
+    public ModuleCommentDTO updateComment(ModuleCommentDTO moduleCommentDTO, Long id) {
+        ModuleComment comment = moduleCommentRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "comment not found"));
+        ModuleComment newComment = moduleCommentMapper.toEntity(moduleCommentDTO);
+
+        newComment.setId(comment.getId());
+        newComment.setCreatedAt(comment.getCreatedAt());
+        newComment.setModule(comment.getModule());
+        newComment.setModuleVersion(comment.getModuleVersion());
+        ModuleComment savedComment = moduleCommentRepository.save(newComment);
+        return moduleCommentMapper.toDTO(savedComment);
+    }
+
+    public void deleteComment(Long id) {
+        ModuleComment comment = moduleCommentRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "module version not found"));
+
+        moduleCommentRepository.delete(comment);
+    }
+
+    public List<ModuleCommentDTO> findAllByModule(Module module) {
+        if (module == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "module not found");
+        }
+
+        return moduleCommentRepository.findAllByModule(module).stream().map(moduleCommentMapper::toDTO).toList();
+    }
+
+    public List<ModuleCommentDTO> findAllByModuleVersion(ModuleVersion moduleVersion) {
+        if (moduleVersion == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "module version not found");
+        }
+
+        return moduleCommentRepository.findAllByModuleVersion(moduleVersion).stream().map(moduleCommentMapper::toDTO).toList();
+    }
+
+}

--- a/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleCommentService.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleCommentService.java
@@ -11,6 +11,7 @@ import com.ipi.mesi_backend_rpg.model.ModuleVersion;
 import com.ipi.mesi_backend_rpg.repository.ModuleCommentRepository;
 import com.ipi.mesi_backend_rpg.repository.ModuleVersionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -59,20 +60,20 @@ public class ModuleCommentService {
         moduleCommentRepository.delete(comment);
     }
 
-    public List<ModuleCommentDTO> findAllByModule(Module module) {
+    public List<ModuleCommentDTO> findAllByModule(Module module, int page, int limit) {
         if (module == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "module not found");
         }
 
-        return moduleCommentRepository.findAllByModule(module).stream().map(moduleCommentMapper::toDTO).toList();
+        return moduleCommentRepository.findAllByModule(module, PageRequest.of(page, limit)).stream().map(moduleCommentMapper::toDTO).toList();
     }
 
-    public List<ModuleCommentDTO> findAllByModuleVersion(ModuleVersion moduleVersion) {
+    public List<ModuleCommentDTO> findAllByModuleVersion(ModuleVersion moduleVersion, int page, int limit) {
         if (moduleVersion == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "module version not found");
         }
 
-        return moduleCommentRepository.findAllByModuleVersion(moduleVersion).stream().map(moduleCommentMapper::toDTO).toList();
+        return moduleCommentRepository.findAllByModuleVersion(moduleVersion, PageRequest.of(page, limit)).stream().map(moduleCommentMapper::toDTO).toList();
     }
 
 }

--- a/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleCommentService.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleCommentService.java
@@ -1,25 +1,18 @@
 package com.ipi.mesi_backend_rpg.service;
 
 import com.ipi.mesi_backend_rpg.dto.ModuleCommentDTO;
-import com.ipi.mesi_backend_rpg.dto.ModuleVersionDTO;
-import com.ipi.mesi_backend_rpg.mapper.BlockMapper;
 import com.ipi.mesi_backend_rpg.mapper.ModuleCommentMapper;
-import com.ipi.mesi_backend_rpg.mapper.ModuleVersionMapper;
 import com.ipi.mesi_backend_rpg.model.Module;
 import com.ipi.mesi_backend_rpg.model.ModuleComment;
 import com.ipi.mesi_backend_rpg.model.ModuleVersion;
 import com.ipi.mesi_backend_rpg.repository.ModuleCommentRepository;
-import com.ipi.mesi_backend_rpg.repository.ModuleVersionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.time.LocalDateTime;
 import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleService.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleService.java
@@ -138,4 +138,9 @@ public class ModuleService {
                 .map(moduleMapper::toDTO)
                 .collect(Collectors.toList());
     }
+
+    public List<ModuleResponseDTO> getMostCommentedModules(int limit, int page) {
+        return moduleRepository.findMostCommentedModules(PageRequest.of(page, limit))
+                .stream().map(moduleMapper::toDTO).collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
Apporte la possibilité d'ajouter des commentaires sur un module, en précisant sur quelle version on commente. Il est ensuite possible de récupérer soit tous les commentaires du module (toutes versions confondues), soit les commentaires de la version spécifique.

Une pagination est mise en place pour la récupération des commentaires (par défaut, page 0, limit 20). Ils ne sont pas intégrés par défaut au DTO du module pour éviter la surchage du payload.
Il est également possible de mettre à jour ou supprimer un commentaire.

Lorsqu'un module ou une version est supprimée, tous les commentaires qui y sont associés le sont aussi.

Enfin, un nouveau point d'entrée dans le ModuleController permet de récupérer les modules les plus commentés (pagination disponible).
