### PR TITLE
Feat/authenticated user

### DIFF
--- a/src/main/java/com/ipi/mesi_backend_rpg/MesiBackendRpgApplication.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/MesiBackendRpgApplication.java
@@ -52,7 +52,7 @@ public class MesiBackendRpgApplication {
             try {
                 User localUser = new User();
                 localUser.setUsername("john_doe");
-                localUser.setEmail("timothe.decool@edu.igensia.com");
+                localUser.setEmail("john.doe@example.com");
 
                 localUser.setCreatedAt(LocalDateTime.now());
                 localUser.setUpdatedAt(LocalDateTime.now());

--- a/src/main/java/com/ipi/mesi_backend_rpg/MesiBackendRpgApplication.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/MesiBackendRpgApplication.java
@@ -52,7 +52,7 @@ public class MesiBackendRpgApplication {
             try {
                 User localUser = new User();
                 localUser.setUsername("john_doe");
-                localUser.setEmail("john.doe@example.com");
+                localUser.setEmail("timothe.decool@edu.igensia.com");
 
                 localUser.setCreatedAt(LocalDateTime.now());
                 localUser.setUpdatedAt(LocalDateTime.now());

--- a/src/main/java/com/ipi/mesi_backend_rpg/configuration/FirebaseAuthenticationFilter.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/configuration/FirebaseAuthenticationFilter.java
@@ -58,4 +58,14 @@ public class FirebaseAuthenticationFilter extends OncePerRequestFilter {
 
         return authorities;
     }
+
+    public FirebaseToken getDecodedToken(HttpServletRequest request) throws FirebaseAuthException {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new RuntimeException("Missing or invalid Authorization header.");
+        }
+
+        String idToken = authHeader.substring(7);
+        return FirebaseAuth.getInstance().verifyIdToken(idToken);
+    }
 }

--- a/src/main/java/com/ipi/mesi_backend_rpg/dto/BlockDTO.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/dto/BlockDTO.java
@@ -25,7 +25,6 @@ public abstract class BlockDTO {
     private String title;
     @NotNull
     private Integer blockOrder;
-    @NotNull
     private UserDTO creator;
     @NotNull
     private String type;

--- a/src/main/java/com/ipi/mesi_backend_rpg/dto/ModuleRequestDTO.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/dto/ModuleRequestDTO.java
@@ -18,10 +18,7 @@ public record ModuleRequestDTO(
         
         @NotNull(message = "Type is not provided.")
         String type,
-        
-        @NotNull(message = "Creator is not provided.")
-        UserDTO creator,
-        
+
         PictureDTO picture,
         
         List<ModuleVersionDTO> versions,

--- a/src/main/java/com/ipi/mesi_backend_rpg/mapper/BlockMapper.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/mapper/BlockMapper.java
@@ -95,8 +95,7 @@ public class BlockMapper {
                     paragraphBlockDTO.getTitle(),
                     paragraphBlockDTO.getBlockOrder(),
                     "paragraph",
-                    userRepository.findById(paragraphBlockDTO.getCreator().id())
-                        .orElseThrow(() -> new IllegalArgumentException("Invalid user id")),
+                    null,
                     paragraphBlockDTO.getParagraph(),
                     paragraphBlockDTO.getStyle()
             );
@@ -108,7 +107,7 @@ public class BlockMapper {
                     integratedModuleBlockDTO.getTitle(),
                     integratedModuleBlockDTO.getBlockOrder(),
                     "block",
-                    userRepository.findById(integratedModuleBlockDTO.getCreator().id()).orElseThrow(() -> new IllegalArgumentException("Invalid user id: " + integratedModuleBlockDTO.getCreator().id())),
+                    null,
                     moduleRepository.findById(integratedModuleBlockDTO.getModuleId()).orElse(null)
             );
         }
@@ -119,7 +118,7 @@ public class BlockMapper {
                     statBlockDTO.getTitle(),
                     statBlockDTO.getBlockOrder(),
                     "stat",
-                    userRepository.findById(statBlockDTO.getCreator().id()).orElseThrow(() -> new IllegalArgumentException("Invalid user : " + statBlockDTO.getCreator().id())),
+                    null,
                     statBlockDTO.getStatRules(),
                     statBlockDTO.getStatValues()
             );
@@ -133,8 +132,9 @@ public class BlockMapper {
                     musicBlockDTO.getTitle(),
                     musicBlockDTO.getBlockOrder(),
                     "music",
-                    userRepository.findById(musicBlockDTO.getCreator().id()).orElseThrow(() -> new IllegalArgumentException("Invalid user : " + musicBlockDTO.getCreator().id()))
+                    null
             );
+
         }
 
         if (blockDTO instanceof PictureBlockDTO pictureBlockDTO) {
@@ -145,7 +145,7 @@ public class BlockMapper {
                     pictureBlockDTO.getTitle(),
                     pictureBlockDTO.getBlockOrder(),
                     "picture",
-                    userRepository.findById(pictureBlockDTO.getCreator().id()).orElseThrow(() -> new IllegalArgumentException("Invalid user: " + pictureBlockDTO.getCreator().id()))
+                    null
             );
         }
 

--- a/src/main/java/com/ipi/mesi_backend_rpg/mapper/ModuleCommentMapper.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/mapper/ModuleCommentMapper.java
@@ -39,8 +39,6 @@ public class ModuleCommentMapper {
                 .orElseThrow(() -> new IllegalArgumentException("Module not found")));
         moduleComment.setModuleVersion(moduleVersionRepository.findById(moduleCommentDTO.moduleVersionId())
                 .orElseThrow(() -> new IllegalArgumentException("ModuleVersion not found")));
-        moduleComment.setUser(userRepository.findById(moduleCommentDTO.user().id())
-                .orElseThrow(() -> new IllegalArgumentException("Utilisateur non trouvé")));
         moduleComment.setComment(moduleCommentDTO.comment());
         return moduleComment;
     }

--- a/src/main/java/com/ipi/mesi_backend_rpg/mapper/ModuleMapper.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/mapper/ModuleMapper.java
@@ -48,30 +48,11 @@ public class ModuleMapper {
     }
 
     public Module toEntity(ModuleRequestDTO moduleRequestDTO) {
-        // Check if creator data is provided
-        if (moduleRequestDTO.creator() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Creator information is required");
-        }
-
-        // Check if creator ID is provided
-        if (moduleRequestDTO.creator().id() == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Creator ID is required");
-        }
-
-        // Log the ID we're looking for to help with debugging
-        Long creatorId = moduleRequestDTO.creator().id();
-        System.out.println("Looking for user with ID: " + creatorId);
-
-        // Try to find the user
-        User creator = userRepository.findById(creatorId)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND, "User not found with ID: " + creatorId));
 
         // Create the module with the found user
         Module module = new Module(
                 moduleRequestDTO.title(),
                 moduleRequestDTO.description(),
-                creator,
                 LocalDateTime.now(),
                 LocalDateTime.now(),
                 moduleRequestDTO.isTemplate(),

--- a/src/main/java/com/ipi/mesi_backend_rpg/mapper/ModuleVersionMapper.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/mapper/ModuleVersionMapper.java
@@ -60,8 +60,7 @@ public class ModuleVersionMapper {
         ModuleVersion moduleVersion = new ModuleVersion();
         moduleVersion.setId(moduleVersionDTO.id());
         moduleVersion.setVersion(moduleVersionDTO.version());
-        moduleVersion.setCreator(userRepository.findById(moduleVersionDTO.creator().id()).orElseThrow(
-                () -> new IllegalArgumentException("Invalid user id: " + moduleVersionDTO.creator().id())));
+        moduleVersion.setCreator(null);
         moduleVersion.setCreatedAt(
                 moduleVersionDTO.createdAt() != null ? moduleVersionDTO.createdAt() : LocalDateTime.now());
         moduleVersion.setPublished(moduleVersionDTO.published());

--- a/src/main/java/com/ipi/mesi_backend_rpg/model/Module.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/model/Module.java
@@ -78,14 +78,8 @@ public class Module {
 
     public Module(String title, String description, User creator, LocalDateTime createdAt, LocalDateTime updatedAt,
             Boolean isTemplate, String type) {
-        this.title = title;
-        this.description = description;
+        this(title, description, createdAt, updatedAt, isTemplate, type);
         this.creator = creator;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.isTemplate = isTemplate;
-        this.type = type;
-
     }
 
     public Module(String title, String description, User creator, LocalDateTime createdAt, LocalDateTime updatedAt,
@@ -94,6 +88,14 @@ public class Module {
         this.picture = picture;
     }
 
+    public Module(String title, String description, LocalDateTime createdAt, LocalDateTime updatedAt, Boolean isTemplate, String type) {
+        this.title = title;
+        this.description = description;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.isTemplate = isTemplate;
+        this.type = type;
+    }
     public void addTag(Tag tag) {
         if (this.tags == null) {
             this.tags = new ArrayList<>();

--- a/src/main/java/com/ipi/mesi_backend_rpg/service/BlockService.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/service/BlockService.java
@@ -35,6 +35,7 @@ public class BlockService {
     private final BlockMapper blockMapper;
     private final ModuleVersionRepository moduleVersionRepository;
     private final UserRepository userRepository;
+    private final UserService userService;
 
     public List<BlockDTO> getAllBlocksByModuleVersionId(Long moduleVersionId) {
         ModuleVersion moduleVersion = moduleVersionRepository.findById(moduleVersionId)
@@ -55,6 +56,7 @@ public class BlockService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Module version not found"));
 
         Block block = blockMapper.toEntity(blockDTO);
+        block.setCreator(userService.getAuthenticatedUser());
         block.setCreatedAt(LocalDate.now());
         block.setUpdatedAt(LocalDate.now());
         blockRepository.save(block);
@@ -76,6 +78,7 @@ public class BlockService {
         Block updatedBlock = blockMapper.toEntity(blockDTO);
         updatedBlock.setId(existingBlock.getId());
         updatedBlock.setCreatedAt(existingBlock.getCreatedAt());
+        updatedBlock.setCreator(existingBlock.getCreator());
         updatedBlock.setUpdatedAt(LocalDate.now());
 
         blockRepository.save(updatedBlock);

--- a/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleCommentService.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleCommentService.java
@@ -38,6 +38,12 @@ public class ModuleCommentService {
     public ModuleCommentDTO updateComment(ModuleCommentDTO moduleCommentDTO, Long id) {
         ModuleComment comment = moduleCommentRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "comment not found"));
+
+        if(!comment.getUser().getId().equals(userService.getAuthenticatedUser().getId()))
+        {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You do not have the right to edit this comment.");
+        }
+
         ModuleComment newComment = moduleCommentMapper.toEntity(moduleCommentDTO);
 
         newComment.setId(comment.getId());

--- a/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleCommentService.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleCommentService.java
@@ -20,6 +20,7 @@ public class ModuleCommentService {
 
     private final ModuleCommentRepository moduleCommentRepository;
     private final ModuleCommentMapper moduleCommentMapper;
+    private final UserService userService;
 
     public ModuleCommentDTO findById(Long id) {
         ModuleComment moduleComment = moduleCommentRepository.findById(id)
@@ -29,6 +30,7 @@ public class ModuleCommentService {
 
     public ModuleCommentDTO createComment(ModuleCommentDTO moduleCommentDTO) {
         ModuleComment moduleComment = moduleCommentMapper.toEntity(moduleCommentDTO);
+        moduleComment.setUser(userService.getAuthenticatedUser());
         ModuleComment saved = moduleCommentRepository.save(moduleComment);
         return moduleCommentMapper.toDTO(saved);
     }
@@ -42,6 +44,7 @@ public class ModuleCommentService {
         newComment.setCreatedAt(comment.getCreatedAt());
         newComment.setModule(comment.getModule());
         newComment.setModuleVersion(comment.getModuleVersion());
+        newComment.setUser(comment.getUser());
         ModuleComment savedComment = moduleCommentRepository.save(newComment);
         return moduleCommentMapper.toDTO(savedComment);
     }

--- a/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleService.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleService.java
@@ -44,6 +44,7 @@ public class ModuleService {
     private final UserRepository userRepository;
 
     private final UserSavedModuleRepository userSavedModuleRepository;
+    private final UserService userService;
 
     public List<ModuleResponseDTO> findAllModules() {
         return moduleRepository.findAll().stream().map(moduleMapper::toDTO).toList();
@@ -56,8 +57,7 @@ public class ModuleService {
 
     public ModuleResponseDTO createModule(ModuleRequestDTO moduleRequestDTO) {
         Module module = moduleMapper.toEntity(moduleRequestDTO);
-        User user = userRepository.findById(moduleRequestDTO.creator().id())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User (creator) not found"));
+        User user = userService.getAuthenticatedUser();
         module.setCreator(user);
 
         GameSystem gameSystem = gameSystemRepository.findById(1L)

--- a/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleVersionService.java
+++ b/src/main/java/com/ipi/mesi_backend_rpg/service/ModuleVersionService.java
@@ -30,6 +30,7 @@ public class ModuleVersionService {
 
     private final BlockService blockService;
     private final BlockMapper blockMapper;
+    private final UserService userService;
 
     public ModuleVersionDTO findById(Long id) {
         ModuleVersion moduleVersion = moduleVersionRepository.findById(id)
@@ -40,6 +41,7 @@ public class ModuleVersionService {
     public ModuleVersionDTO createVersion(Module module, ModuleVersionDTO moduleVersionDTO) {
         ModuleVersion version = moduleVersionMapper.toEntity(moduleVersionDTO);
         version.setModule(module);
+        version.setCreator(userService.getAuthenticatedUser());
         ModuleVersion savedVersion = moduleVersionRepository.save(version);
         return moduleVersionMapper.toDTO(savedVersion);
     }
@@ -50,6 +52,7 @@ public class ModuleVersionService {
         ModuleVersion newVersion = moduleVersionMapper.toEntity(moduleVersionDTO);
         newVersion.setId(version.getId());
         newVersion.setModule(version.getModule());
+        newVersion.setCreator(version.getCreator());
         newVersion.setCreatedAt(version.getCreatedAt());
 
         if (newVersion.getBlocks() != null && !newVersion.getBlocks().isEmpty()) {


### PR DESCRIPTION
Proposition pour faire évoluer la création d'objets en prenant en compte le user authentifié qui réalise la requête.

- méthode getAuthenticatedUser ajoutée dans le userService et qui se fonde sur une nouvelle méthode dans la classe FirebaseAuthenticationFilter
- Pour la création des Module, ModuleVersion, Block et Comment le creator est donné par le getAuthenticatedUser ; pour l'update de ces entités, on récupère celle qui était déjà en base.
- Pour l'update d'un commentaire, on vérifie que le user qui fait la requête est bien celui qui a créé le commentaire original.

Conséquences DTO : dans ModuleRequestDTO, j'ai retiré l'option creator car devenue inutile. Pour les autres DTO, le creator est optionnel et sa valeur sera systématiquement surchargée (si on veut les retirer du DTO, il faudra faire des DTO Request/Response distincts).

Je veux bien vos retours sur la pertinence de la façon de faire, si vous voyez quelque chose de plus optimal.